### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Testbase.yml
+++ b/.github/workflows/Testbase.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Run tests
         run: pytest --cov
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v5.0.7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/Testbase_win.yml
+++ b/.github/workflows/Testbase_win.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Run tests
         run: pytest --cov -n auto
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v4.6.0
+        uses: codecov/codecov-action@v5.0.7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.0.7](https://github.com/codecov/codecov-action/releases/tag/v5.0.7)** on 2024-11-21T12:28:45Z
