### PR TITLE
Added a section to provide optional development dependancies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,18 @@ dependencies = [
 ]
 
 
+
+[project.optional-dependencies]
+dev = [
+    "hatch", 
+    "flake8",
+    "h5py",
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+]
+
+
 [project.urls]
 Homepage = "http://pymodaq.cnrs.fr"
 Source = "https://github.com/PyMoDAQ/pymodaq_data"


### PR DESCRIPTION
The `pyproject.toml` file was modified to include the development dependencies so they can easily be installed with `pip install -e ".[dev]"`