### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5.4.0
+      uses: actions/setup-python@v5.5.0
       with:
         python-version: '3.11'
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4.2.2
  
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.4.0
+        uses: actions/setup-python@v5.5.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -66,7 +66,7 @@ jobs:
           pytest --cov=pymodaq_data -n 1
           mv .coverage coverage/coverage_${{ matrix.os }}_${{ matrix.python-version }}
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
           path: coverage/coverage_${{ matrix.os }}_${{ matrix.python-version }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload badge artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name:  tests_${{runner.os}}_${{matrix.python-version}}
           path: '${{ steps.extract_branch.outputs.branch }}/tests_${{runner.os}}_${{matrix.python-version}}.svg'
@@ -117,7 +117,7 @@ jobs:
           ref: badges
      
       - name: Download badges
-        uses: actions/download-artifact@v4.1.9
+        uses: actions/download-artifact@v4.2.1
 
       - name: Reorganize badges
         run: |
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4.1.9
+        uses: actions/download-artifact@v4.2.1
         with:
           path: ./coverage-reports
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.2](https://github.com/actions/upload-artifact/releases/tag/v4.6.2)** on 2025-03-19T17:47:02Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.2.1](https://github.com/actions/download-artifact/releases/tag/v4.2.1)** on 2025-03-19T15:54:58Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.5.0](https://github.com/actions/setup-python/releases/tag/v5.5.0)** on 2025-03-25T02:43:21Z
