### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5.5.0
+      uses: actions/setup-python@v5.6.0
       with:
         python-version: '3.11'
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4.2.2
  
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.5.0
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -117,7 +117,7 @@ jobs:
           ref: badges
      
       - name: Download badges
-        uses: actions/download-artifact@v4.2.1
+        uses: actions/download-artifact@v4.3.0
 
       - name: Reorganize badges
         run: |
@@ -150,7 +150,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4.2.1
+        uses: actions/download-artifact@v4.3.0
         with:
           path: ./coverage-reports
 
@@ -171,7 +171,7 @@ jobs:
           coverage xml -i
 
       - name: Upload combined coverage report to Codecov
-        uses: codecov/codecov-action@v5.4.0
+        uses: codecov/codecov-action@v5.4.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.4.2](https://github.com/codecov/codecov-action/releases/tag/v5.4.2)** on 2025-04-14T20:02:26Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.6.0](https://github.com/actions/setup-python/releases/tag/v5.6.0)** on 2025-04-24T02:50:16Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.3.0](https://github.com/actions/download-artifact/releases/tag/v4.3.0)** on 2025-04-24T16:28:16Z
