### PR TITLE
feature/use_list_ordering_instead_of_values_in_config 

### DIFF
--- a/src/pymodaq_data/h5modules/saving.py
+++ b/src/pymodaq_data/h5modules/saving.py
@@ -227,7 +227,7 @@ class H5SaverLowLevel(H5Backend):
         """
         if array_type is None:
             if array_to_save is None:
-                array_type = config('data_saving', 'data_type', 'dynamic')
+                array_type = config('data_saving', 'data_type', 'dynamics')[0]
             else:
                 array_type = array_to_save.dtype
 


### PR DESCRIPTION
Related to https://github.com/PyMoDAQ/pymodaq_gui/pull/71

- use first value of lists for the dynamic entry in the config file
