### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
           pytest --cov=pymodaq_data -n 1
           mv .coverage coverage/coverage_${{ matrix.os }}_${{ matrix.python-version }}
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
           path: coverage/coverage_${{ matrix.os }}_${{ matrix.python-version }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload badge artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v5.0.0
         with:
           name:  tests_${{runner.os}}_${{matrix.python-version}}
           path: '${{ steps.extract_branch.outputs.branch }}/tests_${{runner.os}}_${{matrix.python-version}}.svg'
@@ -118,7 +118,7 @@ jobs:
           ref: badges
      
       - name: Download badges
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v6.0.0
 
       - name: Reorganize badges
         run: |
@@ -151,7 +151,7 @@ jobs:
         uses: actions/checkout@v5.0.0
 
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v6.0.0
         with:
           path: ./coverage-reports
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v6.0.0](https://github.com/actions/download-artifact/releases/tag/v6.0.0)** on 2025-10-24T18:19:24Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v5.0.0](https://github.com/actions/upload-artifact/releases/tag/v5.0.0)** on 2025-10-24T18:19:29Z
